### PR TITLE
Add minimal AI-based analysis page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 import streamlit as st
 from modules.datos import display_other_feature_ui
+from modules.match_stats_extractor import display_match_stats_extractor_ui
+from modules.minimal_viz import display_minimal_page
 
 
 def main():
@@ -20,7 +22,8 @@ def main():
         "Selecciona una herramienta:",
         (
             "1. Extractor de Datos de Nowgoal",
-            "2. Extractor de Estadísticas de Partido" # <--- ¡NUEVA OPCIÓN EN EL MENÚ!
+            "2. Extractor de Estadísticas de Partido",
+            "3. Vista Minimal con IA"
         ),
         key="main_tool_selection_final"
     )
@@ -28,9 +31,11 @@ def main():
 
     # Mostrar la interfaz de usuario según la herramienta seleccionada
     if selected_tool == "1. Extractor de Datos de Nowgoal":
-         display_other_feature_ui()
+        display_other_feature_ui()
     elif selected_tool == "2. Extractor de Estadísticas de Partido":
         display_match_stats_extractor_ui()
+    elif selected_tool == "3. Vista Minimal con IA":
+        display_minimal_page()
     
 
 

--- a/modules/minimal_viz.py
+++ b/modules/minimal_viz.py
@@ -1,0 +1,83 @@
+# modules/minimal_viz.py
+import streamlit as st
+import requests
+
+from modules.datos import (
+    fetch_soup_requests_of,
+    get_team_league_info_from_script_of,
+    extract_final_score_of,
+    format_ah_as_decimal_string_of,
+)
+
+try:
+    from modules.datos import get_selenium_driver_of, get_main_match_odds_selenium_of
+except Exception:
+    get_selenium_driver_of = None
+    get_main_match_odds_selenium_of = None
+
+API_URL = "https://api-inference.huggingface.co/models/google/flan-t5-base"
+
+
+def fetch_ai_prediction(prompt: str) -> str:
+    """Attempt to fetch a simple AI prediction using the HuggingFace inference API."""
+    try:
+        response = requests.post(API_URL, json={"inputs": prompt}, timeout=10)
+        if response.status_code == 200:
+            data = response.json()
+            if isinstance(data, list) and data:
+                return data[0].get("generated_text", "")
+            elif isinstance(data, dict) and "generated_text" in data:
+                return data["generated_text"]
+        return f"Error {response.status_code} al obtener prediccion"
+    except Exception as e:
+        return f"No se pudo obtener prediccion AI: {e}"
+
+
+def display_minimal_page() -> None:
+    st.markdown(
+        """
+        <style>
+        .big-title {font-size:2.2em;font-weight:bold;text-align:center;margin-bottom:10px;}
+        .data-box {border:1px solid #ddd;border-radius:5px;padding:10px;margin-bottom:10px;background:#f9f9f9;}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+    st.markdown("<p class='big-title'>Vista Minimal de Partido</p>", unsafe_allow_html=True)
+    match_id = st.text_input("ID del partido", value="2696131")
+    if st.button("Analizar", type="primary"):
+        soup = fetch_soup_requests_of(f"/match/h2h-{match_id}")
+        if not soup:
+            st.error("No se pudo obtener datos del partido")
+            return
+        home_id, away_id, league_id, home_name, away_name, league_name = get_team_league_info_from_script_of(soup)
+        score_display, score_raw = extract_final_score_of(soup)
+        st.markdown(f"### {home_name} vs {away_name}")
+        st.markdown(f"**Liga:** {league_name} (ID {league_id})")
+        st.metric("Marcador Final", score_display)
+        odds_data = {}
+        if get_selenium_driver_of and get_main_match_odds_selenium_of:
+            driver = get_selenium_driver_of()
+            if driver:
+                try:
+                    driver.get(f"https://live18.nowgoal25.com/match/live-{match_id}")
+                    odds_data = get_main_match_odds_selenium_of(driver)
+                finally:
+                    driver.quit()
+        ah_line = format_ah_as_decimal_string_of(odds_data.get("ah_linea_raw", "?"))
+        goals_line = format_ah_as_decimal_string_of(odds_data.get("goals_linea_raw", "?"))
+        st.metric("AH inicial", ah_line)
+        st.metric("Línea de Goles", goals_line)
+        prompt = (
+            f"Analiza el encuentro entre {home_name} y {away_name}. El marcador final fue {score_display}. "
+            f"La línea AH fue {ah_line} y la línea de goles {goals_line}. "
+            "¿Cuál sería el resultado más lógico si se volvieran a enfrentar?"
+        )
+        with st.spinner("Consultando IA gratuita..."):
+            ai_answer = fetch_ai_prediction(prompt)
+        st.subheader("Predicción de IA")
+        st.write(ai_answer)
+
+if __name__ == "__main__":
+    st.set_page_config(layout="wide", page_title="Vista Minimal", initial_sidebar_state="expanded")
+    display_minimal_page()


### PR DESCRIPTION
## Summary
- add new `modules/minimal_viz.py` to provide a simplified interface
- update menu in `app.py` to include the new page
- restore missing import for match stats extractor

## Testing
- `python -m py_compile app.py modules/minimal_viz.py modules/datos.py`
- `pip install -r requirements.txt`
- `PYTHONPATH=. python modules/minimal_viz.py` *(fails due to Streamlit context warnings)*
- `PYTHONPATH=. streamlit run modules/minimal_viz.py --server.headless true --server.port 8501` *(fails to detect external IP due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685a291e4774832dbfe8ad2a48857243